### PR TITLE
Feat: receipt records

### DIFF
--- a/example/lib/example.dart
+++ b/example/lib/example.dart
@@ -17,16 +17,16 @@ void main(List<String> arguments) async {
       await tikiSdk.title.create(ptr, tags: [TitleTag.emailAddress()]);
   print("Created a Title Record with id ${title.id} for PTR: $ptr");
   LicenseRecord first = await tikiSdk.license.create(
-      ptr,
+      title,
       [
         LicenseUse([LicenseUsecase.attribution()])
       ],
       'terms');
   print("Created a License Record with id ${first.id} for PTR: $ptr");
-  tikiSdk.license.guard(ptr, [LicenseUsecase.attribution()],
+  tikiSdk.guard(ptr, [LicenseUsecase.attribution()],
       onPass: () => print(
           "There is a valid License Record for attribution use for Title Record with PTR $ptr"));
-  tikiSdk.license.guard(ptr, [LicenseUsecase.support()],
+  tikiSdk.guard(ptr, [LicenseUsecase.support()],
       onFail: (cause) => print(
           "There is no valid License Record for support use for Title Record with PTR $ptr. Cause: $cause"));
   exit(0);

--- a/example/lib/in_mem.dart
+++ b/example/lib/in_mem.dart
@@ -147,7 +147,6 @@ class InMemBuilders {
     PayableService payableService =
         PayableService(nodeService.database, nodeService);
 
-    return TikiSdk(titleService, licenseService, payableService, nodeService,
-        InMemRegistryService(address: address));
+    return TikiSdk(origin, nodeService, InMemRegistryService(address: address));
   }
 }

--- a/lib/cache/content_schema.dart
+++ b/lib/cache/content_schema.dart
@@ -12,7 +12,8 @@ import '../utils/compact_size.dart';
 enum ContentSchema {
   title(2),
   license(3),
-  payable(4);
+  payable(4),
+  receipt(5);
 
   final int _value;
 

--- a/lib/cache/payable/payable_service.dart
+++ b/lib/cache/payable/payable_service.dart
@@ -48,4 +48,13 @@ class PayableService {
   /// Returns all payables given a [license]
   List<PayableModel> getAll(Uint8List license) =>
       _repository.getByLicense(license);
+
+  void tryAdd(PayableModel payable) {
+    if (payable.transactionId != null) {
+      PayableModel? found = _repository.getById(payable.transactionId!);
+      if (found == null) {
+        _repository.save(payable);
+      }
+    }
+  }
 }

--- a/lib/cache/receipt/receipt_model.dart
+++ b/lib/cache/receipt/receipt_model.dart
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) TIKI Inc.
+ * MIT license. See LICENSE file in root directory.
+ */
+
+import 'dart:typed_data';
+
+import '../../payable_record.dart';
+import '../../receipt_record.dart';
+import '../../utils/bytes.dart';
+import '../../utils/compact_size.dart';
+import 'receipt_repository.dart';
+
+/// Describes a payable against a License Model [LicenseModel]
+class ReceiptModel {
+  /// The corresponding id of the payable
+  Uint8List payable;
+
+  /// The amount paid out
+  String amount;
+
+  /// The transaction id of this record.
+  Uint8List? transactionId;
+
+  /// A human-readable description of the receipt.
+  String? description;
+
+  /// A customer-specific reference identifier
+  String? reference;
+
+  ReceiptModel(this.payable, this.amount,
+      {this.description, this.transactionId, this.reference});
+
+  /// Construct a [PayableModel] from a [map].
+  ///
+  /// Primary use is [PayableRepository] object marshalling.
+  ReceiptModel.fromMap(Map<String, dynamic> map)
+      : payable = map[ReceiptRepository.columnPayable],
+        amount = map[ReceiptRepository.columnAmount],
+        transactionId = map[ReceiptRepository.columnTransactionId],
+        description = map[ReceiptRepository.columnDescription],
+        reference = map[ReceiptRepository.columnReference];
+
+  /// Converts this to Map
+  ///
+  /// Primary use is [PayableRepository] object marshalling.
+  Map toMap() => {
+        ReceiptRepository.columnPayable: payable,
+        ReceiptRepository.columnAmount: amount,
+        ReceiptRepository.columnDescription: description,
+        ReceiptRepository.columnReference: reference,
+        ReceiptRepository.columnTransactionId: transactionId,
+      };
+
+  /// Serializes this to binary.
+  ///
+  /// Primary use is on-chain storage. The [transactionId] and [license] are not
+  /// represented in the serialized output.
+  Uint8List serialize() {
+    return (BytesBuilder()
+          ..add(CompactSize.encode(Bytes.utf8Encode(amount)))
+          ..add(description == null
+              ? Uint8List(1)
+              : CompactSize.encode(Bytes.utf8Encode(description!)))
+          ..add(reference == null
+              ? Uint8List(1)
+              : CompactSize.encode(Bytes.utf8Encode(reference!))))
+        .toBytes();
+  }
+
+  /// Construct a new [PayableModel] from binary data.
+  ///
+  /// See [serialize] for supported binary format.
+  factory ReceiptModel.deserialize(Uint8List payable, Uint8List serialized) =>
+      ReceiptModel.decode(payable, CompactSize.decode(serialized));
+
+  /// Construct a new [PayableModel] from decoded binary data.
+  ///
+  /// See [serialize] for supported binary format.
+  factory ReceiptModel.decode(Uint8List payable, List<Uint8List> bytes) =>
+      ReceiptModel(payable, Bytes.utf8Decode(bytes[0]),
+          description: Bytes.utf8Decode(bytes[1]),
+          reference: Bytes.utf8Decode(bytes[2]));
+
+  ReceiptRecord toRecord(PayableRecord payable) =>
+      ReceiptRecord(Bytes.base64UrlEncode(transactionId!), payable, amount,
+          description: description, reference: reference);
+}

--- a/lib/cache/receipt/receipt_repository.dart
+++ b/lib/cache/receipt/receipt_repository.dart
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) TIKI Inc.
+ * MIT license. See LICENSE file in root directory.
+ */
+
+import 'dart:typed_data';
+
+import 'package:sqlite3/common.dart';
+
+import '../../node/transaction/transaction_repository.dart';
+import '../../utils/bytes.dart';
+import '../license/license_repository.dart';
+import '../payable/payable_repository.dart';
+import 'receipt_model.dart';
+
+/// The repository for [ReceiptModel] persistence.
+class ReceiptRepository {
+  final CommonDatabase _db;
+  static const table = 'receipt_record';
+  static const columnPayable = 'payable';
+  static const columnAmount = 'amount';
+  static const columnDescription = 'description';
+  static const columnTransactionId = 'transaction_id';
+  static const columnReference = 'reference';
+
+  /// Builds a [LicenseRepository] that will use [_db] for persistence.
+  ///
+  /// Calls [_createTable] to ensure the table exists.
+  ReceiptRepository(this._db) {
+    _createTable();
+  }
+
+  /// Creates the [PayableRepository.table] if it does not exist.
+  void _createTable() => _db.execute('''
+    CREATE TABLE IF NOT EXISTS $table (
+     $columnTransactionId BLOB PRIMARY KEY,
+     $columnPayable BLOB,
+     $columnAmount TEXT,
+     $columnDescription TEXT,
+     $columnReference TEXT,
+     FOREIGN KEY($columnPayable) 
+      REFERENCES ${PayableRepository.table}(${PayableRepository.columnTransactionId}),
+     FOREIGN KEY($columnTransactionId) 
+      REFERENCES ${TransactionRepository.table}(${TransactionRepository.columnId})
+      );
+    ''');
+
+  /// Persists [payable] in [_db].
+  void save(ReceiptModel receipt) {
+    Map map = receipt.toMap();
+    _db.execute('''
+    INSERT INTO $table 
+    VALUES ( ?, ?, ?, ?, ?);
+    ''', [
+      map[columnTransactionId],
+      map[columnPayable],
+      map[columnAmount],
+      map[columnDescription],
+      map[columnReference]
+    ]);
+  }
+
+  /// Gets the [ReceiptModel] by [id] from the database.
+  ReceiptModel? getById(Uint8List id) {
+    List<ReceiptModel> receipts = _select(
+        whereStmt: "WHERE $columnTransactionId = x'${Bytes.hexEncode(id)}'");
+    return receipts.isNotEmpty ? receipts.first : null;
+  }
+
+  /// Gets all [PayableModel]s for a [payable]
+  List<ReceiptModel> getByPayable(Uint8List payable) {
+    String where = '''WHERE $columnPayable = 
+      x'${Bytes.hexEncode(payable)}' ORDER BY $table.oid DESC''';
+    return _select(whereStmt: where, params: []);
+  }
+
+  List<ReceiptModel> _select({String? whereStmt, List params = const []}) {
+    ResultSet results = _db.select('''
+      SELECT * FROM $table
+      ${whereStmt ?? ''};
+      ''', params);
+    return _toReceipt(results);
+  }
+
+  List<ReceiptModel> _toReceipt(ResultSet results) {
+    List<ReceiptModel> receipts = [];
+    for (final Row row in results) {
+      Map<String, dynamic> map = {
+        columnTransactionId: row[columnTransactionId],
+        columnPayable: row[columnPayable],
+        columnAmount: row[columnAmount],
+        columnDescription: row[columnDescription],
+        columnReference: row[columnReference]
+      };
+      ReceiptModel license = ReceiptModel.fromMap(map);
+      receipts.add(license);
+    }
+    return receipts;
+  }
+}

--- a/lib/cache/receipt/receipt_service.dart
+++ b/lib/cache/receipt/receipt_service.dart
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) TIKI Inc.
+ * MIT license. See LICENSE file in root directory.
+ */
+
+import 'dart:typed_data';
+
+import '../../node/node_service.dart';
+import '../../node/transaction/transaction_model.dart';
+import '../../utils/bytes.dart';
+import '../content_schema.dart';
+import 'receipt_model.dart';
+import 'receipt_repository.dart';
+
+/// The service to manage [ReceiptModel]s
+class ReceiptService {
+  final ReceiptRepository _repository;
+  final NodeService _nodeService;
+
+  ReceiptService(db, this._nodeService) : _repository = ReceiptRepository(db);
+
+  /// Create a new on-chain [PayableModel]
+  ///
+  /// This method creates a new pending transaction that will be committed
+  /// during assembly of the next block in the chain.
+  Future<ReceiptModel> create(Uint8List payable, String amount,
+      {String? description, DateTime? expiry, String? reference}) async {
+    ReceiptModel receipt = ReceiptModel(payable, amount,
+        description: description, reference: reference);
+
+    Uint8List contents = (BytesBuilder()
+          ..add(ContentSchema.receipt.toCompactSize())
+          ..add(receipt.serialize()))
+        .toBytes();
+
+    String assetRef = "txn://${Bytes.base64UrlEncode(payable)}";
+    TransactionModel transaction =
+        await _nodeService.write(contents, assetRef: assetRef);
+
+    receipt.transactionId = transaction.id!;
+    _repository.save(receipt);
+    return receipt;
+  }
+
+  /// Returns the payable for a [id]
+  ReceiptModel? getById(Uint8List id) => _repository.getById(id);
+
+  /// Returns all payables given a [payable]
+  List<ReceiptModel> getAll(Uint8List payable) =>
+      _repository.getByPayable(payable);
+
+  void tryAdd(ReceiptModel receipt) {
+    if (receipt.transactionId != null) {
+      ReceiptModel? found = _repository.getById(receipt.transactionId!);
+      if (found == null) {
+        _repository.save(receipt);
+      }
+    }
+  }
+}

--- a/lib/payable.dart
+++ b/lib/payable.dart
@@ -7,35 +7,25 @@ import 'dart:typed_data';
 
 import 'cache/payable/payable_model.dart';
 import 'cache/payable/payable_service.dart';
-import 'license.dart';
-import 'license_record.dart';
-import 'payable_record.dart';
+import 'tiki_sdk.dart';
 import 'utils/bytes.dart';
 
 class Payable {
   final PayableService _payableService;
-  final License _license;
+  final TikiSdk _sdk;
 
-  Payable(this._payableService, this._license);
+  Payable(this._payableService, this._sdk);
 
-  Future<PayableRecord> create(String ptr, String amount, String type,
-      {String? description,
-      DateTime? expiry,
-      String? reference,
-      String? origin}) async {
-    LicenseRecord? license = _license.latest(ptr, origin: origin);
-    if (license == null) {
-      throw StateError("Failed to create Payable. No license found for Ptr.");
-    }
+  Future<PayableRecord> create(
+      LicenseRecord license, String amount, String type,
+      {String? description, DateTime? expiry, String? reference}) async {
     Uint8List licenseId = Bytes.base64UrlDecode(license.id!);
     PayableModel payable = await _payableService.create(licenseId, amount, type,
         description: description, expiry: expiry, reference: reference);
     return payable.toRecord(license);
   }
 
-  List<PayableRecord> all(String ptr, {String? origin}) {
-    LicenseRecord? license = _license.latest(ptr, origin: origin);
-    if (license == null) return List.empty();
+  List<PayableRecord> all(LicenseRecord license) {
     Uint8List licenseId = Bytes.base64UrlDecode(license.id!);
     List<PayableModel> payables = _payableService.getAll(licenseId);
     return payables.map((payable) => payable.toRecord(license)).toList();
@@ -45,7 +35,7 @@ class Payable {
     PayableModel? payable = _payableService.getById(Bytes.base64UrlDecode(id));
     if (payable == null) return null;
     LicenseRecord? license =
-        _license.get(Bytes.base64UrlEncode(payable.license));
+        _sdk.license.get(Bytes.base64UrlEncode(payable.license));
     if (license == null) return null;
     return payable.toRecord(license);
   }

--- a/lib/receipt.dart
+++ b/lib/receipt.dart
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) TIKI Inc.
+ * MIT license. See LICENSE file in root directory.
+ */
+
+import 'dart:typed_data';
+
+import 'cache/receipt/receipt_model.dart';
+import 'cache/receipt/receipt_service.dart';
+import 'receipt_record.dart';
+import 'tiki_sdk.dart';
+import 'utils/bytes.dart';
+
+class Receipt {
+  final ReceiptService _receiptService;
+  final TikiSdk _sdk;
+
+  Receipt(this._receiptService, this._sdk);
+
+  Future<ReceiptRecord> create(PayableRecord payable, String amount,
+      {String? description, String? reference}) async {
+    Uint8List payableId = Bytes.base64UrlDecode(payable.id!);
+    ReceiptModel receipt = await _receiptService.create(payableId, amount,
+        description: description, reference: reference);
+    return receipt.toRecord(payable);
+  }
+
+  List<ReceiptRecord> all(PayableRecord payable) {
+    Uint8List payableId = Bytes.base64UrlDecode(payable.id!);
+    List<ReceiptModel> receipts = _receiptService.getAll(payableId);
+    return receipts.map((receipt) => receipt.toRecord(payable)).toList();
+  }
+
+  ReceiptRecord? get(String id) {
+    ReceiptModel? receipt = _receiptService.getById(Bytes.base64UrlDecode(id));
+    if (receipt == null) return null;
+    PayableRecord? payable =
+        _sdk.payable.get(Bytes.base64UrlEncode(receipt.payable));
+    if (payable == null) return null;
+    return receipt.toRecord(payable);
+  }
+}

--- a/lib/receipt_record.dart
+++ b/lib/receipt_record.dart
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) TIKI Inc.
+ * MIT license. See LICENSE file in root directory.
+ */
+
+import 'license_record.dart';
+import 'payable_record.dart';
+
+/// Payable Records describe a payment issued or owed in accordance with
+/// the terms of a [LicenseRecord].
+class ReceiptRecord {
+  /// This record's id
+  String? id;
+
+  /// The [PayableRecord] for this receipt
+  PayableRecord payable;
+
+  /// The total amount. Can be a simple numeric value, or an atypical value
+  /// such as downloadable content.
+  String amount;
+
+  /// A human-readable description of the payable
+  String? description;
+
+  /// A customer-specific reference identifier
+  String? reference;
+
+  ReceiptRecord(this.id, this.payable, this.amount,
+      {this.description, this.reference});
+}

--- a/test/cache/receipt/receipt_repository_test.dart
+++ b/test/cache/receipt/receipt_repository_test.dart
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) TIKI Inc.
+ * MIT license. See LICENSE file in root directory.
+ */
+
+import 'package:sqlite3/sqlite3.dart';
+import 'package:test/test.dart';
+import 'package:tiki_sdk_dart/cache/license/license_model.dart';
+import 'package:tiki_sdk_dart/cache/license/license_repository.dart';
+import 'package:tiki_sdk_dart/cache/license/license_use.dart';
+import 'package:tiki_sdk_dart/cache/license/license_usecase.dart';
+import 'package:tiki_sdk_dart/cache/payable/payable_model.dart';
+import 'package:tiki_sdk_dart/cache/payable/payable_repository.dart';
+import 'package:tiki_sdk_dart/cache/receipt/receipt_model.dart';
+import 'package:tiki_sdk_dart/cache/receipt/receipt_repository.dart';
+import 'package:tiki_sdk_dart/cache/title/title_model.dart';
+import 'package:tiki_sdk_dart/cache/title/title_repository.dart';
+import 'package:tiki_sdk_dart/utils/bytes.dart';
+import 'package:uuid/uuid.dart';
+
+void main() {
+  group('Receipt Repository Tests', () {
+    test('getById - Success', () {
+      Database db = sqlite3.openInMemory();
+      TitleRepository titleRepository = TitleRepository(db);
+      LicenseRepository licenseRepository = LicenseRepository(db);
+      PayableRepository payableRepository = PayableRepository(db);
+      ReceiptRepository receiptRepository = ReceiptRepository(db);
+
+      TitleModel title = TitleModel('com.mytiki.test', const Uuid().v4(),
+          transactionId: Bytes.utf8Encode(const Uuid().v4()));
+      titleRepository.save(title);
+      LicenseModel license = LicenseModel(
+          title.transactionId!,
+          [
+            LicenseUse([LicenseUsecase.analytics()],
+                destinations: ["*.mytiki.com"])
+          ],
+          'terms',
+          transactionId: Bytes.utf8Encode(const Uuid().v4()));
+      licenseRepository.save(license);
+
+      PayableModel payable = PayableModel(
+          license.transactionId!, "all the monies", "fake",
+          description: "Im a description",
+          reference: "ooo I got a ref",
+          expiry: DateTime(2000),
+          transactionId: Bytes.utf8Encode(const Uuid().v4()));
+      payableRepository.save(payable);
+
+      ReceiptModel receipt = ReceiptModel(payable.transactionId!, "some money",
+          description: "Im a description",
+          reference: "ooo I got a ref",
+          transactionId: Bytes.utf8Encode(const Uuid().v4()));
+      receiptRepository.save(receipt);
+
+      ReceiptModel? found = receiptRepository.getById(receipt.transactionId!);
+      expect(found != null, true);
+      expect(found!.payable, payable.transactionId);
+      expect(found.amount, "some money");
+      expect(found.description, "Im a description");
+      expect(found.reference, "ooo I got a ref");
+    });
+  });
+}

--- a/test/cache/receipt/receipt_service_test.dart
+++ b/test/cache/receipt/receipt_service_test.dart
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) TIKI Inc.
+ * MIT license. See LICENSE file in root directory.
+ */
+
+import 'dart:typed_data';
+
+import 'package:test/test.dart';
+import 'package:tiki_sdk_dart/cache/license/license_service.dart';
+import 'package:tiki_sdk_dart/cache/license/license_use.dart';
+import 'package:tiki_sdk_dart/cache/license/license_usecase.dart';
+import 'package:tiki_sdk_dart/cache/payable/payable_service.dart';
+import 'package:tiki_sdk_dart/cache/receipt/receipt_model.dart';
+import 'package:tiki_sdk_dart/cache/receipt/receipt_service.dart';
+import 'package:tiki_sdk_dart/cache/title/title_service.dart';
+import 'package:tiki_sdk_dart/node/node_service.dart';
+import 'package:tiki_sdk_dart/utils/bytes.dart';
+
+import '../../in_mem.dart';
+
+void main() {
+  group('Receipt Service Tests', () {
+    test('create - Success', () async {
+      NodeService nodeService = await InMemBuilders.nodeService();
+      TitleService titleService =
+          TitleService('com.mytiki', nodeService, nodeService.database);
+      LicenseService licenseService =
+          LicenseService(nodeService.database, nodeService);
+      PayableService payableService =
+          PayableService(nodeService.database, nodeService);
+
+      Uint8List titleId = (await titleService.create('test')).transactionId!;
+      Uint8List licenseId = (await licenseService.create(
+              titleId,
+              [
+                LicenseUse([LicenseUsecase.custom('test')])
+              ],
+              'terms'))
+          .transactionId!;
+      Uint8List payableId = (await payableService.create(
+              licenseId, "all the monies", "fake",
+              description: "Im a description",
+              reference: "ooo I got a ref",
+              expiry: DateTime(2000)))
+          .transactionId!;
+
+      ReceiptService receiptService =
+          ReceiptService(nodeService.database, nodeService);
+      ReceiptModel receipt = await receiptService.create(
+          payableId, "some money",
+          description: "Im a description", reference: "ooo I got a ref");
+
+      expect(Bytes.memEquals(receipt.payable, payableId), true);
+      expect(receipt.transactionId != null, true);
+      expect(receipt.amount, "some money");
+      expect(receipt.description, "Im a description");
+      expect(receipt.reference, "ooo I got a ref");
+    });
+
+    test('getAll - Success', () async {
+      NodeService nodeService = await InMemBuilders.nodeService();
+      TitleService titleService =
+          TitleService('com.mytiki', nodeService, nodeService.database);
+      LicenseService licenseService =
+          LicenseService(nodeService.database, nodeService);
+      PayableService payableService =
+          PayableService(nodeService.database, nodeService);
+
+      Uint8List titleId = (await titleService.create('test')).transactionId!;
+      Uint8List licenseId = (await licenseService.create(
+              titleId,
+              [
+                LicenseUse([LicenseUsecase.custom('test')])
+              ],
+              'terms'))
+          .transactionId!;
+      Uint8List payableId = (await payableService.create(
+              licenseId, "all the monies", "fake",
+              description: "Im a description",
+              reference: "ooo I got a ref",
+              expiry: DateTime(2000)))
+          .transactionId!;
+
+      ReceiptService receiptService =
+          ReceiptService(nodeService.database, nodeService);
+      await receiptService.create(payableId, "some money",
+          description: "Im a description", reference: "ooo I got a ref");
+
+      List<ReceiptModel> receipts = receiptService.getAll(payableId);
+      expect(receipts.length, 1);
+      ReceiptModel receipt = receipts.first;
+      expect(Bytes.memEquals(receipt.payable, payableId), true);
+      expect(receipt.transactionId != null, true);
+      expect(receipt.amount, "some money");
+      expect(receipt.description, "Im a description");
+      expect(receipt.reference, "ooo I got a ref");
+    });
+  });
+}

--- a/test/in_mem.dart
+++ b/test/in_mem.dart
@@ -7,9 +7,6 @@ import 'dart:typed_data';
 
 import 'package:sqlite3/common.dart';
 import 'package:sqlite3/sqlite3.dart';
-import 'package:tiki_sdk_dart/cache/license/license_service.dart';
-import 'package:tiki_sdk_dart/cache/payable/payable_service.dart';
-import 'package:tiki_sdk_dart/cache/title/title_service.dart';
 import 'package:tiki_sdk_dart/l0/auth/auth_service.dart';
 import 'package:tiki_sdk_dart/l0/registry/registry_model_rsp.dart';
 import 'package:tiki_sdk_dart/l0/registry/registry_service.dart';
@@ -139,14 +136,6 @@ class InMemBuilders {
     String address = await TikiSdk.withId(id, keyStorage);
     NodeService nodeService =
         await InMemBuilders.nodeService(id: id, keyStorage: keyStorage);
-
-    TitleService titleService =
-        TitleService(origin, nodeService, nodeService.database);
-    LicenseService licenseService =
-        LicenseService(nodeService.database, nodeService);
-    PayableService payableService =
-        PayableService(nodeService.database, nodeService);
-
     return TikiSdk(origin, nodeService, InMemRegistryService(address: address));
   }
 }

--- a/test/in_mem.dart
+++ b/test/in_mem.dart
@@ -147,7 +147,6 @@ class InMemBuilders {
     PayableService payableService =
         PayableService(nodeService.database, nodeService);
 
-    return TikiSdk(titleService, licenseService, payableService, nodeService,
-        InMemRegistryService(address: address));
+    return TikiSdk(origin, nodeService, InMemRegistryService(address: address));
   }
 }

--- a/test/tiki_sdk_test.dart
+++ b/test/tiki_sdk_test.dart
@@ -38,8 +38,10 @@ void main() {
       String ptr = const Uuid().v4();
       String hashedPtr = base64.encode(
           Digest("SHA3-256").process(Uint8List.fromList(utf8.encode(ptr))));
+      TitleRecord title =
+          await tikiSdk.title.create(ptr, tags: [TitleTag.emailAddress()]);
       LicenseRecord first = await tikiSdk.license.create(
-          ptr,
+          title,
           [
             LicenseUse([LicenseUsecase.attribution()])
           ],
@@ -49,7 +51,7 @@ void main() {
           LicenseUsecase.attribution().value);
       expect(first.terms, 'terms');
       expect(first.title.hashedPtr, hashedPtr);
-      LicenseRecord second = await tikiSdk.license.create(ptr, [], 'terms');
+      LicenseRecord second = await tikiSdk.license.create(title, [], 'terms');
       expect(second.uses.length, 0);
     });
   });


### PR DESCRIPTION
Adds receipts
- receipt slice
- receipt api

Updates API
- reverts to a more standard/uniform model where the parent record is passed in to create the child record. most notably this affects the license create method, which no longer will auto-create a title record, instead it requires a title record. to address this, there is now a method to lookup a title record using a ptr record, this allows SDK implementations to continue to offer a single endpoint for creating licenses. 

fixes #305 